### PR TITLE
test(tnr): test public key private key from same mnemonic

### DIFF
--- a/src/core/arianee/arianee.test.ts
+++ b/src/core/arianee/arianee.test.ts
@@ -1,7 +1,8 @@
 import {aria} from "../../configurations";
-import { NETWORK, networkURL } from "../../models/networkConfiguration";
+import {NETWORK, networkURL} from "../../models/networkConfiguration";
 import {ArianeeHttpClient} from "../libs/arianeeHttpClient/arianeeHttpClient";
-import { Arianee } from "./arianee";
+import {Arianee} from "./arianee";
+
 const myFetchMock = jest.fn();
 import appConfigurations from "../../configurations/appConfigurations";
 
@@ -26,7 +27,7 @@ jest.mock("../libs/arianeeHttpClient/arianeeHttpClient", () => ({
         httpProvider: "https://sokol.poa.network",
         chainId: 77
       });
-    }
+    };
   }
 }));
 
@@ -64,5 +65,44 @@ describe("Arianee", () => {
         expect(faucetUrl).toBe(appConfigurations.mainnet.faucetUrl);
       });
     });
+  });
+  describe('should output same wallet public key for each arianeeJS version', () => {
+
+    describe('with a same mnemonic', () => {
+
+      const mnemonic = 'hire super odor text avocado detail remain air end live sauce wife';
+      const privateKey = '0x048f9038e7c38c225d8e98078bd8a28923a13a9c255190975258afebd56506d3';
+      const publicKey = '0x640D422Af7a6e9A21adC919b59609ED745ABED58';
+
+      test('should be same public key fromMnemonic', async () => {
+        const arianee = await new Arianee().init(NETWORK.testnet);
+        const wallet = arianee.fromMnemonic(mnemonic);
+        expect(wallet.privateKey).toBe(privateKey);
+        expect(wallet.publicKey).toBe(publicKey);
+      });
+
+      test('should be same public key fromPrivateKey', async () => {
+        const arianee = await new Arianee().init(NETWORK.testnet);
+        const wallet = arianee.fromPrivateKey(privateKey);
+        expect(wallet.publicKey).toBe(publicKey);
+        expect(wallet.privateKey).toBe(privateKey);
+
+      });
+    });
+
+    describe('from passphrase', () => {
+
+      const passphrase = 'passphrase';
+      const publicKey = "0x8E7a86D892d88BA42C780ce7E557B0EbbcFDC650";
+      const privateKey = '0x0000000000000000000000000000000000000000000070617373706872617365';
+
+      test('should be same public key fromPrivateKey', async () => {
+        const arianee = await new Arianee().init(NETWORK.testnet);
+        const wallet = arianee.fromPassPhrase(passphrase);
+        expect(wallet.publicKey).toBe(publicKey);
+        expect(wallet.privateKey).toBe(privateKey);
+      });
+    });
+
   });
 });


### PR DESCRIPTION
To be sure that same wallet is output from mnemonic when we update web3js version