### PR TITLE
feat(multichain): add typing

### DIFF
--- a/src/models/networkConfiguration.ts
+++ b/src/models/networkConfiguration.ts
@@ -1,3 +1,4 @@
+
 export enum NETWORK {
   testnet = 'testnet',
   mainnet = 'mainnet',
@@ -17,5 +18,28 @@ export const networkURL = {
   [NETWORK.arianeeTestnet]: 'https://cert.arianee.net/contractAddresses/arianeetest.json',
   [NETWORK.arialabs]: 'https://cert.arianee.net/contractAddresses/arialabs.json',
   [NETWORK.stadetoulousain]: 'https://cert.arianee.net/contractAddresses/stadetoulousain.json',
-  [NETWORK.ysl]: 'https://cert.arianee.net/contractAddresses/ysl.json',
+  [NETWORK.ysl]: 'https://cert.arianee.net/contractAddresses/ysl.json'
+};
+
+export type ChainId = number;
+export enum ChainType {
+  mainnet = 'mainnet',
+  testnet = 'testnet',
+}
+
+export const CHAIN_TYPE_DETAILED: {
+  [key in ChainType]: { name: NETWORK; id: ChainId }[];
+} = {
+  testnet: [
+    { name: NETWORK.testnet, id: 77 },
+    { name: NETWORK.mumbai, id: 80001 },
+    { name: NETWORK.arianeeTestnet, id: 1337 }
+  ],
+  mainnet: [
+    { name: NETWORK.mainnet, id: 99 },
+    { name: NETWORK.polygon, id: 137 },
+    { name: NETWORK.stadetoulousain, id: 137 },
+    { name: NETWORK.ysl, id: 137 },
+    { name: NETWORK.arialabs, id: 137 }
+  ]
 };


### PR DESCRIPTION
A proposal of multichain typing.
Developers can easily access both chain name and chain id of a particular chain type by using:
```js
const testnetChainsNames = CHAIN_TYPE_DETAILED['testnet'].map(details => details.name);
const testnetChainsIds = CHAIN_TYPE_DETAILED['testnet'].map(details => details.id);

// or simply iterate over a property
CHAIN_TYPE_DETAILED['testnet'].forEach(testnetChain => {
...
});
```