### PR TITLE
fix(certificateParentMerger): append child externalContents to parent ones instead of overriding (ARI-3292)

### DIFF
--- a/src/core/libs/certificateParentMerger/certificateParentMerger.test.ts
+++ b/src/core/libs/certificateParentMerger/certificateParentMerger.test.ts
@@ -63,4 +63,56 @@ describe('certificateParentMerger', () => {
       ]
     });
   });
+
+  const parentNotice = { type: 'website', title: 'Notice', url: 'https://example.com/notice' };
+  const childLink = { type: 'website', title: 'Child link', url: 'https://example.com/child' };
+
+  test('it should concatenate child externalContents after the parent ones instead of overriding them (ARI-3292)', () => {
+    const merged = certificateParentMerger([
+      { name: 'parent name', externalContents: [parentNotice] },
+      { name: 'child name', externalContents: [childLink] }
+    ]);
+
+    expect(merged.name).toEqual('child name');
+    expect(merged.externalContents).toEqual([parentNotice, childLink]);
+  });
+
+  test('it should keep parent externalContents when the child has none', () => {
+    const merged = certificateParentMerger([
+      { externalContents: [parentNotice] },
+      { name: 'child name' }
+    ]);
+
+    expect(merged.externalContents).toEqual([parentNotice]);
+  });
+
+  test('it should remove externalContents duplicated between parent and child', () => {
+    const merged = certificateParentMerger([
+      { externalContents: [parentNotice] },
+      { externalContents: [{ ...parentNotice }, childLink] }
+    ]);
+
+    expect(merged.externalContents).toEqual([parentNotice, childLink]);
+  });
+
+  test('it should concatenate i18n externalContents by language and keep parent-only languages (ARI-3292)', () => {
+    const parentNoticeEn = { type: 'website', title: 'Notice EN', url: 'https://example.com/notice-en' };
+    const parentNoticeFr = { type: 'website', title: 'Notice FR', url: 'https://example.com/notice-fr' };
+    const childLinkEn = { type: 'website', title: 'Child link EN', url: 'https://example.com/child-en' };
+
+    const merged = certificateParentMerger([
+      {
+        i18n: [
+          { language: 'fr-FR', externalContents: [parentNoticeFr] },
+          { language: 'en-US', externalContents: [parentNoticeEn] }
+        ]
+      },
+      { i18n: [{ language: 'en-US', externalContents: [childLinkEn] }] }
+    ]);
+
+    expect((merged as any).i18n).toEqual([
+      { language: 'fr-FR', externalContents: [parentNoticeFr] },
+      { language: 'en-US', externalContents: [parentNoticeEn, childLinkEn] }
+    ]);
+  });
 });

--- a/src/core/libs/certificateParentMerger/certificateParentMerger.ts
+++ b/src/core/libs/certificateParentMerger/certificateParentMerger.ts
@@ -1,5 +1,44 @@
-import { mergeWith } from 'lodash';
+import { isArray, isEqual, mergeWith, uniqWith } from 'lodash';
 import { ArianeeCertificatei18nV3 } from '../../../models/jsonSchema/certificates/ArianeeProducti18n';
+
+/**
+ * Concatenates parent and child externalContents (parent entries first) and
+ * removes strictly identical duplicates (ARI-3292).
+ */
+const concatExternalContents = (parentValue: any[], childValue: any[]): any[] =>
+  uniqWith([...parentValue, ...childValue], isEqual);
+
+/**
+ * Merges parent and child i18n arrays by matching language (instead of by
+ * index): matching languages are deep merged with externalContents
+ * concatenated, parent-only languages are kept and child-only languages are
+ * appended (ARI-3292).
+ */
+const mergeI18nByLanguage = (parentI18n: any[], childI18n: any[]): any[] => {
+  const merged = parentI18n.map(parentLang => {
+    const childLang = childI18n.find(c => c && c.language === (parentLang && parentLang.language));
+    return childLang ? mergeWith({}, parentLang, childLang, parentMergerCustomizer) : parentLang;
+  });
+  const childOnlyLanguages = childI18n.filter(
+    childLang => !parentI18n.some(p => p && p.language === (childLang && childLang.language))
+  );
+  return [...merged, ...childOnlyLanguages];
+};
+
+/**
+ * lodash mergeWith customizer: externalContents arrays are concatenated (parent
+ * first, deduplicated) and i18n entries are merged by language, instead of the
+ * child overriding the parent. Any other key falls back to the default merge.
+ */
+const parentMergerCustomizer = (parentValue: any, childValue: any, key?: string): any => {
+  if (key === 'externalContents' && isArray(parentValue) && isArray(childValue)) {
+    return concatExternalContents(parentValue, childValue);
+  }
+  if (key === 'i18n' && isArray(parentValue) && isArray(childValue)) {
+    return mergeI18nByLanguage(parentValue, childValue);
+  }
+  return undefined;
+};
 
 /**
  * Will be merged from 0 to last content
@@ -9,7 +48,7 @@ import { ArianeeCertificatei18nV3 } from '../../../models/jsonSchema/certificate
 export const certificateParentMerger = (override: Array<any>):ArianeeCertificatei18nV3 => {
   const content = {};
   override.forEach(d => {
-    mergeWith(content, d);
+    mergeWith(content, d, parentMergerCustomizer);
   });
 
   return content as ArianeeCertificatei18nV3;


### PR DESCRIPTION
## Quoi

`certificateParentMerger` fusionnait parent/enfant avec `mergeWith` sans customizer : les tableaux étaient fusionnés index par index, donc le 1er `externalContents` de l'enfant écrasait la notice du parent. Désormais les `externalContents` sont **concaténés** (parent d'abord, dédoublonnage des entrées identiques).

Pendant côté SDK legacy du fix backend [ArianeeBrandDataHub#3846](https://github.com/Arianee/ArianeeBrandDataHub/pull/3846) (mêmes corrections dans [wallet-api#133](https://github.com/Arianee/wallet-api/pull/133) et [arianee-sdk#421](https://github.com/Arianee/arianee-sdk/pull/421)).

> ⚠️ **Repo dormant** : dernier commit septembre 2024, aucun commit depuis 12 mois. Le package npm `@arianee/arianeejs` (1.119.0) est toujours publié et non déprécié, d'où ce correctif pour les intégrations legacy. À merger seulement si le repo est encore considéré comme supporté — sinon, à fermer.

## Comment

`mergeWith` reçoit désormais un customizer (lodash déjà utilisé) :
- `externalContents` concaténés (parent d'abord, dédoublonnage `uniqWith(isEqual)`) ;
- `i18n` mergé **par langue** (langues parent seules conservées, langues enfant seules ajoutées), avec concaténation des `externalContents` par langue ;
- les autres clés gardent le comportement de merge existant.

## Tests

- Le test existant (`it should merge in order parents`) reste vert.
- 4 nouveaux cas : concat, parent seul, dédoublonnage, i18n par langue. Couverture 100% du fichier.

Ticket : [ARI-3292](https://linear.app/arianee/issue/ARI-3292/gestion-external-content-dpp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)